### PR TITLE
Always show tooltip

### DIFF
--- a/Minesweeper/client/main.js
+++ b/Minesweeper/client/main.js
@@ -2369,12 +2369,6 @@ function followCursor(e) {
     const col = Math.floor(e.offsetX / TILE_SIZE);
     hoverTile = board.getTileXY(col, row);
 
-    // if not showing hints don't show tooltip
-    if (!showHintsCheckBox.checked && !analysisMode && !justPressedAnalyse) {
-        tooltip.innerText = "";
-        return;
-    }
-
     //console.log("Following cursor at X=" + e.offsetX + ", Y=" + e.offsetY);
 
     if (dragging && analysisMode) {
@@ -2407,7 +2401,12 @@ function followCursor(e) {
         return;
     } else {
         const tile = board.getTileXY(col, row);
-        tooltip.innerText = tile.asText() + " " + tile.getHintText();
+        // if not showing hints don't show hint
+        if (showHintsCheckBox.checked || analysisMode || justPressedAnalyse) {
+            tooltip.innerText = tile.asText() + " " + tile.getHintText();
+        } else {
+            tooltip.innerText = tile.asText();
+        }
         tooltip.style.display = "inline-block";
     }
 


### PR DESCRIPTION
Deployed here (with the changes from all 3 PRs): https://nineteendo.github.io/JSMinesweeper

If show hints is disabled, the coordinates will now still be shown on the tooltip.