### PR TITLE
Add auto retry

### DIFF
--- a/Minesweeper/client/main.js
+++ b/Minesweeper/client/main.js
@@ -64,6 +64,7 @@ const reductionCheckBox = document.getElementById("reduction");
 const autoPlayCheckBox = document.getElementById("autoplay");
 const showHintsCheckBox = document.getElementById("showhints");
 const acceptGuessesCheckBox = document.getElementById("acceptguesses");
+const autoRetryCheckBox = document.getElementById("autoretry");
 const seedText = document.getElementById("seed");
 const gameTypeSafe = document.getElementById("gameTypeSafe");
 const gameTypeZero = document.getElementById("gameTypeZero");
@@ -3064,6 +3065,11 @@ async function sendActionsMessage(message) {
     // update the mine count if a flag has changed
     if (prevMineCounter != board.bombs_left) {
         window.requestAnimationFrame(() => updateMineCount(board.bombs_left));
+    }
+
+    if (board.isGameover() && !board.won && autoRetryCheckBox.checked) {
+        apply();
+        return;
     }
 
     // update the graphical board

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
             <label><input type="checkbox" class="checkbox" id="showhints" onclick="updateHints()" checked /> <span>Show hints</span></label>
             <label><input type="checkbox" class="checkbox" id="autoplay" onclick="if (this.checked) startSolver()" checked /> <span>Auto play</span></label>
             <label><input type="checkbox" class="checkbox" id="acceptguesses" onclick="if (document.getElementById('autoplay').checked && this.checked) startSolver()" /> <span>Accept guesses</span></label>
+            <label><input type="checkbox" class="checkbox" id="autoretry" /> <span>Auto retry</span></label>
 
         </div>
 


### PR DESCRIPTION
Deployed here (with the changes from all 4 PRs): https://nineteendo.github.io/JSMinesweeper

When the game is lost, a new game will be started automatically. This is useful when trying to find a seed to solve a difficult board, or when playing risky efficiency.