### PR TITLE
Unflag tiles around zero

### DIFF
--- a/Minesweeper/client/MinesweeperGame.js
+++ b/Minesweeper/client/MinesweeperGame.js
@@ -769,7 +769,11 @@ class ServerGame {
 				
 				for (let adjTile of this.getAdjacent(tile)) {
 					
-					if (adjTile.isCovered() && !adjTile.isFlagged()) {  // if not covered and not a flag
+					if (adjTile.isCovered()) {  // if not covered
+						if (adjTile.isFlagged()) {
+							adjTile.toggleFlag();
+							reply.tiles.push({"action" : 2, "index" : adjTile.getIndex(), "flag" : tile.isFlagged()});
+						}
 						adjTile.setNotCovered();  // it will be uncovered in a bit
 						if (adjTile.is3BV) {
 							this.cleared3BV++;

--- a/Minesweeper/client/main.js
+++ b/Minesweeper/client/main.js
@@ -2694,12 +2694,12 @@ function on_click(event) {
                 return;
             }
 
-            if (!board.isStarted()) {
-                console.log("Can't flag until the game has started!");
-                return;
-            } else {
+            // if (!board.isStarted()) {
+            //     console.log("Can't flag until the game has started!");
+            //     return;
+            // } else {
                 message = { "header": board.getMessageHeader(), "actions": [{ "index": board.xy_to_index(col, row), "action": 2 }] };
-            }
+            // }
 
         } else {
             console.log("Mouse button " + button + " ignored");


### PR DESCRIPTION
Deployed here (with the changes from all 6 PRs): https://nineteendo.github.io/JSMinesweeper

Tile around a zero are now unflagged like on minesweeper.online.
You can now flag before the game has started. (in my opinion this was an arbitrary restriction)